### PR TITLE
add sampling_relevant marker to graphql.operation.type on server span

### DIFF
--- a/spec/spans.yml
+++ b/spec/spans.yml
@@ -28,6 +28,7 @@ groups:
       > This prevents potential security issues and ensures span names remain meaningful.
     attributes:
       - ref: graphql.operation.type
+        sampling_relevant: true
         requirement_level:
           conditionally_required: If parsing succeeded
       - ref: graphql.operation.name


### PR DESCRIPTION
Mark `graphql.operation.type` as `sampling_relevant: true` on the `span.graphql.server` span, enabling head-based samplers to makedecisions based on operation type (query/mutation/subscription).

This follows the pattern from HTTP (`http.request.method`), DB (`db.operation.name`), and GenAI (`gen_ai.operation.name`) where the primary operation classifier on the root span is marked as sampling
relevant. Internal spans are not marked since they inherit the sampling decision from the root span.
